### PR TITLE
Adding Norm Shape Covariance

### DIFF
--- a/src/FitBase/Measurement1D.cxx
+++ b/src/FitBase/Measurement1D.cxx
@@ -606,11 +606,8 @@ void Measurement1D::FinaliseMeasurement() {
   // Comment this out until the covariance/data scaling is consistent!
   StatUtils::SetDataErrorFromCov(fDataHist, fFullCovar, 1E-38);
   
-  std::cout << "I made it to the first barrier" << std::endl;
-
   // If shape only, set covar and fDecomp using the shape-only matrix (if set)
   if (fIsShape && fShapeCovar && FitPar::Config().GetParB("UseShapeCovar")) {
-	std::cout << "I made it past the first barrier" << std::endl;
     if (covar)
       delete covar;
     covar = StatUtils::GetInvert(fShapeCovar, true);
@@ -640,36 +637,17 @@ void Measurement1D::FinaliseMeasurement() {
 
   fIsNS = FitPar::Config().GetParB("UseNormShapeCovariance");
 	
-  std::cout << "I made it to the second barrier" << std::endl;
   if (fIsNS) {
     if (covar)
       delete covar;
       
-    std::cout << "I made it past the second barrier" << std::endl;
-
-    //std::cout<<"** fFullCovar : ";
-    //fFullCovar->Print();
-
     fNSCovar = StatUtils::ExtractNSCovar(fFullCovar, fDataHist, 1e-38);
-
-    //std::cout<<"** fNSCovar : ";
-    //fNSCovar->Print();
 
     fDataNSHist = StatUtils::InitToNS(fDataHist, 1e-38);
     StatUtils::SetDataErrorFromCov(fDataNSHist, fNSCovar, 1e-38, false);
 
-    //std::cout<<"** fDataHist : ";
-    //fDataHist->Print("all");
-
-    //std::cout<<"** fDataNSHist : ";
-    //fDataNSHist->Print("all");
-
     covar = StatUtils::GetInvert(fNSCovar);
     fInvNormalCovar = StatUtils::GetInvert(fFullCovar);
-
-    //std::cout<<"** covar : ";
-    //covar->Print();
-
 
   }	
 

--- a/src/FitBase/Measurement1D.h
+++ b/src/FitBase/Measurement1D.h
@@ -645,6 +645,16 @@ protected:
   bool fIsWriting;
   bool fSaveFine;
 
+  // ***** NS covar modifications *****
+
+  bool fIsNS;                   ///< Flag : Perform fit in the NS space
+  TH1D* fDataNSHist;            ///< Data histogram decomposed into shape and norm parts
+  TH1D* fMCNSHist;              ///< MC histogram decomposed into shape and norm parts
+  TMatrixDSym* fNSCovar;        ///< NS covariance matrix
+  TMatrixDSym* fInvNormalCovar; ///< Inverse of the normal cov to print the usual chi2
+
+  // ***** end NS covar modifications *****
+
   /// OLD STUFF TO REMOVE
   TH1D* fMCHist_PDG[61]; ///< REMOVE OLD MC PDG Plot
 

--- a/src/FitBase/Measurement2D.h
+++ b/src/FitBase/Measurement2D.h
@@ -625,6 +625,19 @@ protected:
   // Arrays for data entries
   Double_t *fDataValues; ///< REMOVE data bin contents
   Double_t *fDataErrors; ///< REMOVE data bin errors
+
+  // ***** NS covar modifications *****
+
+  bool fIsNS;                   ///< Flag : Perform fit in the NS space
+  TH1D* fData1DHist;            ///< 1D data histogram, useful for the Norm/Shape computations
+  TH2I* fMapNS;                 ///< Map histogram used to convert 2D hist into 1D NS hist
+  TH1D* fDataNS1DHist;          ///< 1D Data histogram decomposed into shape and norm parts
+  TH1D* fMCNS1DHist;            ///< 1D MC histogram decomposed into shape and norm parts
+  TMatrixDSym* fNSCovar;        ///< NS covariance matrix
+  TMatrixDSym* fInvNormalCovar; ///< Inverse of the normal cov to get the usual chi2
+
+  // ***** end NS covar modifications *****
+
 };
 
 /*! @} */

--- a/src/Statistical/StatUtils.cxx
+++ b/src/Statistical/StatUtils.cxx
@@ -21,6 +21,7 @@
 #include "GeneralUtils.h"
 #include "NuisConfig.h"
 #include "TH1D.h"
+#include "TVector.h"
 
 //*******************************************************************
 Double_t StatUtils::GetChi2FromDiag(TH1D *data, TH1D *mc, TH1I *mask) {
@@ -1368,6 +1369,140 @@ TMatrixDSym *StatUtils::ExtractShapeOnlyCovar(TMatrixDSym *full_covar,
   }
   return shape_covar;
 }
+
+
+// ***** NS covar modifications *****
+
+// "Norm-Shape" covariance
+TMatrixDSym *StatUtils::ExtractNSCovar(TMatrixDSym *full_covar,
+				       TH1 *data_hist,
+				       double shape_scale) {
+
+  int nbins = full_covar->GetNrows();
+  TMatrixDSym *NS_covar = new TMatrixDSym(nbins);
+
+  int replaced_bin_index = nbins-1; // w/ 0 the index of the 1st bin
+
+  // Check nobody is being silly
+  if (data_hist->GetNbinsX() != nbins)
+    {
+      NUIS_ERR(WRN, "Inconsistent matrix and data histogram passed to "
+	       "StatUtils::ExtractNSCovar!");
+      NUIS_ERR(WRN, "data_hist has " << data_hist->GetNbinsX() << " matrix has "
+	       << nbins);
+      int err_bins = data_hist->GetNbinsX();
+      if (nbins > err_bins)
+	err_bins = nbins;
+      for (int i = 0; i < err_bins; ++i) {
+	NUIS_ERR(WRN, "Matrix diag. = " << (*full_covar)(i, i) << " data = "
+		 << data_hist->GetBinContent(i + 1));
+      }
+      return NULL;
+    }
+
+  double total_data = 0;
+  double total_covar = 0;
+  std::vector<double> total_rows_covar;
+  double temp_sum = 0;
+
+  // Initial loop to calculate some constants
+  for (int i = 0; i < nbins; ++i) {
+    total_data += data_hist->GetBinContent(i + 1) ;
+    temp_sum = 0;
+    for (int j = 0; j < nbins; ++j) {
+      total_covar += (*full_covar)(i, j);
+      temp_sum += (*full_covar)(i, j);
+    }
+    total_rows_covar.push_back(temp_sum);
+  }
+
+  if (total_data == 0 || total_covar == 0 || nbins < 2) {
+    NUIS_ERR(WRN, "Stupid matrix or data histogram passed to "
+	     "StatUtils::ExtractNSCovar! Ignoring...");
+    return NULL;
+  }
+
+  NUIS_LOG(SAM, "Norm error = " << sqrt(total_covar) / total_data);
+
+
+  // Now loop over and calculate the NS covariance matrix
+  for (int i = 0; i < nbins; ++i) {
+
+    double data_i = data_hist->GetBinContent(i + 1);
+
+    for (int j = 0; j < nbins; ++j) {
+
+      double data_j = data_hist->GetBinContent(j + 1);
+
+      // check if we're on the row/column of the removed bin
+      if (i == replaced_bin_index || j == replaced_bin_index) {
+
+        if (i == replaced_bin_index && j == replaced_bin_index) {
+          (*NS_covar)(i, j) = total_covar;
+        }
+
+        else if (i == replaced_bin_index){
+          (*NS_covar)(i, j) = shape_scale * 
+	    (total_rows_covar[j] - data_j * total_covar / total_data) / total_data;
+        }
+
+        else { // j == replaced_bin_index
+          (*NS_covar)(i, j) = shape_scale * 
+	    (total_rows_covar[i] - data_i * total_covar/ total_data) / total_data;
+        }
+      }
+      else {
+	double term1 = (*full_covar)(i, j);
+	double term2 = - data_i * total_rows_covar[j] / total_data;
+	double term3 = - data_j * total_rows_covar[i] / total_data;
+	double term4 = data_i * data_j * total_covar / total_data / total_data;
+
+	(*NS_covar)(i, j) = shape_scale * shape_scale * 
+	  (term1 + term2 + term3 + term4) / total_data / total_data;
+      }
+    }
+  }
+
+  return NS_covar;
+}
+
+
+TH1D *StatUtils::InitToNS(TH1D *hist, double shape_scale) {
+
+  int nbins = hist->GetNbinsX();
+  int replaced_bin_index = nbins-1;
+
+  std::string name_hist = std::string(hist->GetName());
+
+  TH1D *NS_hist = (TH1D *) hist->Clone();
+  NS_hist->SetDirectory(NULL);
+
+  // First get the norm
+  Double_t norm = 0.0;
+  for (int i=0 ; i<nbins ; i++) {
+    norm += hist->GetBinContent(i + 1);
+  }
+
+  for (int i=0 ; i<nbins ; i++) {
+    // Replace one bin by the norm
+    if (i == replaced_bin_index) {
+      NS_hist->SetBinContent(i + 1, norm);
+      //  NS_hist->SetBinError(i + 1, sqrt((*NS_covar)(i, i)));
+    }
+    // Normalize the others
+    else {
+      NS_hist->SetBinContent(i + 1, hist->GetBinContent(i + 1) * shape_scale / norm);
+      //NS_hist->SetBinError(i + 1, sqrt((*NS_covar)(i, i)));
+    }
+  }
+
+  return NS_hist;
+}
+
+// ***** end NS covar modifications *****
+
+
+
 
 TMatrixDSym *StatUtils::ExtractShapeOnlyCovar(TMatrixDSym *full_covar,
     TH2D *data_hist, TH2I *map,

--- a/src/Statistical/StatUtils.h
+++ b/src/Statistical/StatUtils.h
@@ -291,6 +291,14 @@ TMatrixDSym *GetCovarFromTextFile(std::string covfile, int dim);
 /// \brief Calls GetMatrixFromRootFile and turns it into a TMatrixDSym
 TMatrixDSym *GetCovarFromRootFile(std::string covfile, std::string histname);
 
+// ***** NS covar modifications *****
+
+// "Norm-Shape" covariance
+TMatrixDSym* ExtractNSCovar(TMatrixDSym *full_covar, TH1 *data_hist, double data_scale);
+TH1D* InitToNS(TH1D *hist, double data_scale);
+
+// ***** end NS covar modifications *****
+
 }; // namespace StatUtils
 
 /*! @} */


### PR DESCRIPTION
Addition of Norm Shape Covariance as an alternate test statistic to mitigate Peelle's Pertinent Puzzle. Add `<config UseNormShapeCovariance='true'/>` to your xml card file or add `-q UseNormShapeCovariance='true'` to your `nuismin` command. Developed by Stephen Dolan and Jaafar Chakrani. 