### PR TITLE
Gaussian pull term fix

### DIFF
--- a/src/FitBase/ParamPull.cxx
+++ b/src/FitBase/ParamPull.cxx
@@ -674,7 +674,7 @@ double ParamPull::GetLikelihood() {
 
   // Gaussian Calculation with correlations
   case kGausPull:
-    like = StatUtils::GetChi2FromCov(fDataHist, fMCHist, fInvCovar, NULL);
+    like = StatUtils::GetChi2FromCov(fDataHist, fMCHist, fInvCovar, NULL, 1., 1E76, NULL, false);
     like *= 1E-76;
     break;
 

--- a/src/Statistical/StatUtils.cxx
+++ b/src/Statistical/StatUtils.cxx
@@ -108,7 +108,8 @@ Double_t StatUtils::GetChi2FromDiag(TH2D *data, TH2D *mc, TH2I *map,
 //*******************************************************************
 Double_t StatUtils::GetChi2FromCov(TH1D *data, TH1D *mc, TMatrixDSym *invcov,
                                    TH1I *mask, double data_scale,
-                                   double covar_scale, TH1D *outchi2perbin) {
+                                   double covar_scale, TH1D *outchi2perbin,
+                                   bool SkipEmptyBin) {
   //*******************************************************************
 
   static bool first = true;
@@ -184,9 +185,13 @@ Double_t StatUtils::GetChi2FromCov(TH1D *data, TH1D *mc, TMatrixDSym *invcov,
                         << calc_data->GetXaxis()->GetBinLowEdge(j + 1) << " -- "
                         << calc_data->GetXaxis()->GetBinUpEdge(j + 1) << "].");
 
-      if (((calc_data->GetBinContent(i + 1) != 0) &&
-           (calc_mc->GetBinContent(i + 1) != 0)) &&
-          ((*calc_cov)(i, j) != 0)) {
+      bool SkipThisEntry = false;
+      if( (*calc_cov)(i, j) == 0 ) SkipThisEntry = true;
+      if( SkipEmptyBin && 
+          ( (calc_data->GetBinContent(i + 1) == 0) || 
+            (calc_mc->GetBinContent(i + 1) == 0) ) ) SkipThisEntry = true;
+
+      if(!SkipThisEntry){
 
         NUIS_LOG(DEB, "[CHI2]\t\t Chi2 contribution (i,j) = (" << i << "," << j
                                                                << ")");

--- a/src/Statistical/StatUtils.h
+++ b/src/Statistical/StatUtils.h
@@ -71,7 +71,8 @@ Double_t GetChi2FromDiag(TH2D *data, TH2D *mc, TH2I *map = NULL,
 //! Get Chi2 using an inverted covariance for the data
 Double_t GetChi2FromCov(TH1D *data, TH1D *mc, TMatrixDSym *invcov,
                         TH1I *mask = NULL, double data_scale = 1,
-                        double covar_scale = 1E76, TH1D *outchi2perbin = NULL);
+                        double covar_scale = 1E76, TH1D *outchi2perbin = NULL,
+                        bool SkipEmptyBin=true);
 
 //! Get Chi2 using an inverted covariance for the data
 //! Plots converted to 1D histograms before using 1D calculation.


### PR DESCRIPTION
Chi2 calculation skips the bins where data=0 OR mc=0 OR CovInv=0. This is find for actual Data vs MC comparison, but we use this feature also in the penalty terms for the nuisance parameters. But when we use "fraction" version (i.e., sigmas), the nominal ("data") is at zero, so the penalties are not calculated. Here I added additional boolean in the  `StatUtils::GetChi2FromCov` function `SkipEmptyBin`, and skips "zero" bins when it is set to true. Default is true, so backward compatible, but for the ParamPull penalty calculation, I set this to false.