### PR TITLE
Run PlotUtils::MaskBins for the case where we give mask hist from root file

### DIFF
--- a/src/FitBase/Measurement1D.cxx
+++ b/src/FitBase/Measurement1D.cxx
@@ -702,6 +702,10 @@ void Measurement1D::FinaliseMeasurement() {
     NUIS_LOG(SAM, "Loaded mask histogram: " << fSettings.GetS("maskhist")
                                             << " from "
                                             << fSettings.GetS("maskfile"));
+
+    // Apply masking by setting masked data bins to zero
+    PlotUtils::MaskBins(fDataHist, fMaskHist);
+
   } else if (fIsMask) { // Setup bin masks using sample name
 
     std::string curname = fName;

--- a/src/FitBase/Measurement2D.cxx
+++ b/src/FitBase/Measurement2D.cxx
@@ -710,6 +710,10 @@ void Measurement2D::FinaliseMeasurement() {
     NUIS_LOG(SAM, "Loaded mask histogram: " << fSettings.GetS("maskhist")
                                             << " from "
                                             << fSettings.GetS("maskfile"));
+
+    // Apply masking by setting masked data bins to zero
+    PlotUtils::MaskBins(fDataHist, fMaskHist);
+
   } else if (fIsMask) { // Setup bin masks using sample name
 
     std::string curname = fName;


### PR DESCRIPTION
I'm giving the making from a TH(1,2)I histogram and give the path/name to the card, e.g.,,
```
<sample name="T2K_NuMu_CC0pi_C_XSec_2DPcos" input="GENIE:/home/jskim/data/GENIE/AR23_20i_00_000/Target_1000060120/Nu_14/T2K_ND/240709_Afro/14_1000060120_CC_v3_4_0_AR23_20i_00_000.gprep.root" maskfile="/home/jskim/240708_Tension2024_Workshop/ConditionalCov/T2K_Carbon_Afro/SixParams/maskhist.root" maskhist="hmask"/>
``` 
but found data histogram is not masked. I think we need to run `PlotUtils::MaskBins` after we read the histogram inside `FinaliseMeasurement` function.