### PR TITLE
Produce Nuisance flat-tree within CLI

### DIFF
--- a/CLI/nuis-gen
+++ b/CLI/nuis-gen
@@ -202,7 +202,6 @@ while [[ ${#} -gt 0 ]]; do
     --flat)
       FLATTREE="true"
       echo "[OPT]: ${NUIS_BREADCRUMBS} -- Will produce Nuisance flat-tree"
-      shift # past argument
       ;;
 
     *) # unknown option

--- a/CLI/nuis-gen
+++ b/CLI/nuis-gen
@@ -21,6 +21,7 @@ function nuis_gen_help {
   echo -e "\t  -P|--probe <numu|nue|numubar|nuebar> : Set probe particle. If -e is used, this is also passed to \'nuis flux\'."
   echo -e "\t  -o|--output-file <output.root>       : defaults to <GENERATOR>.<probe>.<flux_file>.<flux_hist>.<seed>.evts.root"
   echo -e "\t  --seed <int>                         : Integer to use as random seed. Defaults to \${RANDOM}"
+  echo -e "\t  --flat                               : Produce Nuisance flat-tree"
   echo -e ""
 }
 
@@ -71,6 +72,8 @@ FLUX_DESCRIPTOR=""
 FLUX_MeV="off"
 
 SEED=
+
+FLATTREE="false"
 
 FORWARDED_ARGS=()
 
@@ -196,6 +199,12 @@ while [[ ${#} -gt 0 ]]; do
       shift # past argument
       ;;
 
+    --flat)
+      FLATTREE="true"
+      echo "[OPT]: ${NUIS_BREADCRUMBS} -- Will produce Nuisance flat-tree"
+      shift # past argument
+      ;;
+
     *) # unknown option
       FORWARDED_ARGS+=("${key}")
       ;;
@@ -317,3 +326,8 @@ NUIS_BREADCRUMBS=${NUIS_BREADCRUMBS} \
   FLUX_MeV=${FLUX_MeV} \
   SEED=${SEED} \
   ${COMMAND}-${VERB} "${FORWARDED_ARGS[@]}"
+
+
+if [ ${FLATTREE} == "true" ]; then
+  nuisflat -f GenericVectors -i ${VERB}:${OUTPUT_FILENAME} -o ${OUTPUT_FILENAME/.root/_NUISFLAT.root}
+fi

--- a/src/InputHandler/GiBUUNativeInputHandler.cxx
+++ b/src/InputHandler/GiBUUNativeInputHandler.cxx
@@ -368,7 +368,7 @@ void GiBUUNativeInputHandler::CalcNUISANCEKinematics() {
    
     if(dist<6) {
      
-	std::cout<<"Dropping Particle in Neucleus"<<std::endl;
+	std::cout<<"Dropping Particle in Nucleus"<<std::endl;
 	continue;
 
     }

--- a/src/InputHandler/GiBUUNativeInputHandler.cxx
+++ b/src/InputHandler/GiBUUNativeInputHandler.cxx
@@ -368,7 +368,7 @@ void GiBUUNativeInputHandler::CalcNUISANCEKinematics() {
    
     if(dist<6) {
      
-	std::cout<<"Dropping Particle in Neucleus"<<std::end;
+	std::cout<<"Dropping Particle in Neucleus"<<std::endl;
 	continue;
 
     }


### PR DESCRIPTION
What I used
`nuis-gen NuWro -E T2K_ND -t C -P numu -n 1000 -o NuWroTest.root --flat`
Just after generation it produce flat tree
![image](https://github.com/user-attachments/assets/15cbf539-1c9e-4b42-8cf3-1c5370c2df88)
![image](https://github.com/user-attachments/assets/208f8dbb-c2c9-4749-871e-01485aaa27c0)
and tree looks fine
![image](https://github.com/user-attachments/assets/62deb203-585f-44a5-8eef-02b0310f27bb)


fixed also compilation issue in gibuu converter
