### PR TITLE
Added sigma baryons and invariant mass in the print, removed repetition of npi+

### DIFF
--- a/src/InputHandler/NuWroInputHandler.cxx
+++ b/src/InputHandler/NuWroInputHandler.cxx
@@ -430,15 +430,18 @@ void NuWroInputHandler::Print(){
 	   << "\t\t|->      anty = " << fNuWroEvent->flag.anty << std::endl
 	   << "\t\t|-> res_delta = " << fNuWroEvent->flag.res_delta << std::endl
 	   << "\t\t|->      npi+ = " << event1_nof(fNuWroEvent, 211) << std::endl
-	   << "\t\t|->      npi+ = " << event1_nof(fNuWroEvent, 211) << std::endl
            << "\t\t|->      npi- = " << event1_nof(fNuWroEvent, -211) << std::endl
            << "\t\t|->      npi0 = " << event1_nof(fNuWroEvent, 111) << std::endl
            << "\t\t|->      neta = " << event1_nof(fNuWroEvent, 221) << std::endl
            << "\t\t|->       nK+ = " << event1_nof(fNuWroEvent, 321) << std::endl
            << "\t\t|->       nK0 = " << event1_nof(fNuWroEvent, 311) << std::endl
-           << "\t\t|->    nlamda = " << event1_nof(fNuWroEvent, 3122) << std::endl
+           << "\t\t|->   nlambda = " << event1_nof(fNuWroEvent, 3122) << std::endl
+	   << "\t\t|->   nsigma+ = " << event1_nof(fNuWroEvent, 3222) << std::endl
+           << "\t\t|->   nsigma- = " << event1_nof(fNuWroEvent, 3112) << std::endl
+	   << "\t\t|->   nsigma0 = " << event1_nof(fNuWroEvent, 3212) << std::endl	
            << "\t\t|->   nproton = " << event1_nof(fNuWroEvent, 2212) << std::endl
-           << "\t\t|->  nneutron = " << event1_nof(fNuWroEvent, 2112));
+           << "\t\t|->  nneutron = " << event1_nof(fNuWroEvent, 2112) << std::endl
+           << "\t\t|->         W = " << fNuWroEvent->W());
 }
 
 #endif


### PR DESCRIPTION
Adding invariant mass in the print would be helpful to get an idea about the event. I added sigma baryons also since I noticed its presence in electron antineutrino - carbon interactions in NuWro 21.09.2, although it was only one out of a million events. The event was "res = 1" and NUISANCE print made it appear that the interaction produced only piminus in resonance which did not make any sense. 