### PR TITLE
Fix uBooNE CC1MuNp implementation. 

### DIFF
--- a/src/FitBase/Measurement1D.cxx
+++ b/src/FitBase/Measurement1D.cxx
@@ -602,17 +602,16 @@ void Measurement1D::FinaliseMeasurement() {
     fDecomp = StatUtils::GetDecomp(fFullCovar);
   }
 
-  // Push the diagonals of fFullCovar onto the data histogram
-  // Comment this out until the covariance/data scaling is consistent!
+  // Push the diagonals of fFullCovar onto the data histogram, and check that they are consisntent
+  // This is a useful check for inconsistent data releases, or inconsistent covariance matrix units, or simply wrong data releases...
+  // Assumes that the covariance matrix should be scaled by 1E-38
   StatUtils::SetDataErrorFromCov(fDataHist, fFullCovar, 1E-38);
   
   // If shape only, set covar and fDecomp using the shape-only matrix (if set)
   if (fIsShape && fShapeCovar && FitPar::Config().GetParB("UseShapeCovar")) {
-    if (covar)
-      delete covar;
+    if (covar) delete covar;
     covar = StatUtils::GetInvert(fShapeCovar, true);
-    if (fDecomp)
-      delete fDecomp;
+    if (fDecomp) delete fDecomp;
     fDecomp = StatUtils::GetDecomp(fFullCovar);
 
     fUseShapeNormDecomp = FitPar::Config().GetParB("UseShapeNormDecomp");
@@ -625,18 +624,15 @@ void Measurement1D::FinaliseMeasurement() {
           fNormError += (*fFullCovar)[i][j];
         }
       }
-
       NUIS_LOG(SAM, "Sample: " << fName
                                << ", using shape/norm decomp with norm error: "
                                << fNormError);
     }
-
   }
 
-  // ***** NS covar modifications *****
+  // ***** norm-shape (NS) covariance modifications *****
 
   fIsNS = FitPar::Config().GetParB("UseNormShapeCovariance");
-	
   if (fIsNS) {
     if (covar)
       delete covar;
@@ -648,9 +644,7 @@ void Measurement1D::FinaliseMeasurement() {
 
     covar = StatUtils::GetInvert(fNSCovar);
     fInvNormalCovar = StatUtils::GetInvert(fFullCovar);
-
   }	
-
   // ***** end NS covar modifications *****
 
 

--- a/src/MicroBooNE/MicroBooNE_CC1Mu2p_XSec_1D_nu.cxx
+++ b/src/MicroBooNE/MicroBooNE_CC1Mu2p_XSec_1D_nu.cxx
@@ -80,66 +80,6 @@ MicroBooNE_CC1Mu2p_XSec_1D_nu::MicroBooNE_CC1Mu2p_XSec_1D_nu(nuiskey samplekey) 
 
 
 bool MicroBooNE_CC1Mu2p_XSec_1D_nu::isSignal(FitEvent* event) {
-  
-  // apapadop
-  /*static int counter  = 0;
-  static double old_mom = 0.;
-  double new_mom = event->GetHMFSParticle(13)->fP.Vect().Mag();
-  if (new_mom < 100 || new_mom > 1200) { return false; }
-  bool signal = SignalDef::MicroBooNE::isCC1Mu2p(event, EnuMin, EnuMax);
-  
-    if (old_mom != new_mom) {  
-
-      old_mom = new_mom; 
-
-      if (signal) {
-
-	int ProtonCounter = 0;
-	std::vector<int> ProtonIndices = event->GetAllFSProtonIndices();
-	std::vector<int> SignalProtonIndices;
-
-	for (int i = 0; i < (int)(ProtonIndices.size()); i++) {
-
-	  double mom = event->GetParticleMom( ProtonIndices.at(i) );
-	  if (mom > 300 && mom < 1000) {
-
-	    ProtonCounter++;
-	    SignalProtonIndices.push_back( ProtonIndices.at(i) );
-
-	  }
-
-	}
-
-	if (ProtonCounter != 2) { return false; }
-
-	TVector3 vpmu = event->GetHMFSParticle(13)->fP.Vect();
-	TVector3 vplead = event->GetParticleP3(SignalProtonIndices.at(0) );
-	TVector3 vprecoil = event->GetParticleP3( SignalProtonIndices.at(1) );
-
-	if ( vplead.Mag() < vprecoil.Mag() ) {
-
-	  TVector3 temp = vplead;
-	  vplead = vprecoil;
-	  vprecoil = temp;
-
-	}
-
-	TVector3 vSumP = vplead + vprecoil;
-	TVector3 vSumAll = vpmu + vplead + vprecoil;
-
-	double DeltaPT = vSumAll.Pt() / 1000.; // GeV/c                                                                                                                                                         
-	double CosThetaP_Lab = cos( vplead.Angle(vprecoil) );
-	double CosThetaMu_Both = cos( vpmu.Angle(vSumP) );
-
-	cout << "event = " << counter << ", mu mom = " << new_mom/1000. << ", p lead mom = " << vplead.Mag()/1000. << ", p recoil mom = " << vprecoil.Mag()/1000. << std::endl;
-	cout << "      DeltaPT = " << DeltaPT  << ", opening_angle_protons_lab = " << CosThetaP_Lab << ", opening_angle_mu_both = " << CosThetaMu_Both << endl;
-      }
-
-      ++counter;
-
-    }
-    // end of apapadop
-    */
   return SignalDef::MicroBooNE::isCC1Mu2p(event, EnuMin, EnuMax);
 };
 

--- a/src/Statistical/StatUtils.cxx
+++ b/src/Statistical/StatUtils.cxx
@@ -1225,7 +1225,7 @@ void StatUtils::SetDataErrorFromCov(TH1D *DataHist, TMatrixDSym *cov,
   }
 
   // Set bin errors form cov diag
-  // Check if the errors are set
+  // Check first if the errors are set on the data histogram
   bool ErrorsSet = false;
   for (int i = 0; i < DataHist->GetNbinsX(); i++) {
     if (ErrorsSet == true)
@@ -1234,7 +1234,7 @@ void StatUtils::SetDataErrorFromCov(TH1D *DataHist, TMatrixDSym *cov,
       ErrorsSet = true;
   }
 
-  // Now loop over
+  // Now loop over and check
   if (ErrorsSet && ErrorCheck) {
     for (int i = 0; i < DataHist->GetNbinsX(); i++) {
       double DataHisterr = DataHist->GetBinError(i + 1);


### PR DESCRIPTION
The paper has an interesting data release which initially disagrees with our root files (which were provided by uBooNE). 

Now the data histogram and covariance matrix is in cm2/40Ar nucleus, which is consistent with paper figures. 

The paper data release states that the result is both in cm2/nucleon and cm2/40Ar nucleus, which is incorrect (https://arxiv.org/src/2010.02390v1/anc/supplementalMaterials.pdf). 

When scaling up the provided covariance in NUISANCE by 40*40, it agrees with the paper data release.

On a test 100k event file, the chi2/ndof are reasonable and agree with paper: 

```
[LOG Minmzr]:- Getting likelihoods...                                : -2logL
[LOG Minmzr]:- |-> MicroBooNE_CC1MuNp_XSec_1DPmu_nu                  : 21.7024/6
[LOG Minmzr]:- |-> MicroBooNE_CC1MuNp_XSec_1Dcosmu_nu                : 26.3846/12
[LOG Minmzr]:- |-> MicroBooNE_CC1MuNp_XSec_1DPp_nu                   : 18.6303/10
[LOG Minmzr]:- |-> MicroBooNE_CC1MuNp_XSec_1Dcosp_nu                 : 11/9
[LOG Minmzr]:- |-> MicroBooNE_CC1MuNp_XSec_1Dthetamup_nu             : 10.8749/6
```   

Thanks to Jake McKean for pointing this out in https://github.com/NUISANCEMC/nuisance/issues/80 and on #nuisancehelp on slack