### PR TITLE
Fix compilation wiht NEUT5

### DIFF
--- a/cmake/Modules/NUISANCEDependencies.cmake
+++ b/cmake/Modules/NUISANCEDependencies.cmake
@@ -135,6 +135,7 @@ if (NEUT_ENABLED)
     if(NEUT_VERSION VERSION_LESS 6.0.0)
         LIST(APPEND NUISANCENEUT_COMPILE_OPTIONS -DNEUT_LEGACY_API_ENABLED)
         SET(NEUT_LEGACY_API_ENABLED TRUE)
+        target_compile_definitions(GeneratorCompileDependencies INTERFACE NEUT_LEGACY_API)
     endif()
 
     if(NEUTReWeight_ENABLED)


### PR DESCRIPTION
Here:
https://github.com/NUISANCEMC/nuisance/blob/87b372f2e589d3ca2a00142b45769223f8d1ec26/src/InputHandler/NEUTInputHandler.cxx#L3
to compile with NEUT 5 we have to pass defition otherise it reads NEUT6 fsi hist whcih results in VERY funny error

![blarb](https://github.com/user-attachments/assets/1a632b9e-8e6e-4bda-abbc-5a86e7440eac)
