### PR TITLE
Move from using std::regex to long boring string comparison. std::reg…

### DIFF
--- a/src/FCN/SampleList.cxx
+++ b/src/FCN/SampleList.cxx
@@ -671,8 +671,6 @@ MeasurementBase *CreateSample(nuiskey samplekey) {
   std::string type = samplekey.GetS("type");
   std::string fkdt = "";
 
-  std::regex pattern_MINERvA_NukeCC1pip_1D("MINERvA_NukeCC1pip_(.*?)_XSec_1D(.*?)_nu");
-  std::smatch matches_MINERvA_NukeCC1pip_1D;
 
   /*
      ANL CCQE Samples
@@ -1400,6 +1398,7 @@ MeasurementBase *CreateSample(nuiskey samplekey) {
         return (new MINERvA_CCCOHPI_XSec_joint(samplekey));
       } else if (!name.compare("MINERvA_CCCOHPI_XSec_1DQ2_joint")) {
         return (new MINERvA_CCCOHPI_XSec_joint(samplekey));
+
       } else if (!name.compare("MINERvA_NukeCC0pi_CH_XSec_2D_nu")) {
         return (new MINERvA_NukeCC0pi_CH_XSec_2D_nu(samplekey));
       } else if (!name.compare("MINERvA_NukeCC0pi_C_XSec_2D_nu")) {
@@ -1410,6 +1409,7 @@ MeasurementBase *CreateSample(nuiskey samplekey) {
         return (new MINERvA_NukeCC0pi_Fe_XSec_2D_nu(samplekey));
       } else if (!name.compare("MINERvA_NukeCC0pi_Pb_XSec_2D_nu")) {
         return (new MINERvA_NukeCC0pi_Pb_XSec_2D_nu(samplekey));
+
       } else if (!name.compare("MINERvA_NukeCC0pi_CH_C_Flux_XSec_2D_nu")) {
         return (new MINERvA_NukeCC0pi_CH_C_Flux_XSec_2D_nu(samplekey));
       } else if (!name.compare("MINERvA_NukeCC0pi_CH_H2O_Flux_XSec_2D_nu")) {
@@ -1418,7 +1418,47 @@ MeasurementBase *CreateSample(nuiskey samplekey) {
         return (new MINERvA_NukeCC0pi_CH_Fe_Flux_XSec_2D_nu(samplekey));
       } else if (!name.compare("MINERvA_NukeCC0pi_CH_Pb_Flux_XSec_2D_nu")) {
         return (new MINERvA_NukeCC0pi_CH_Pb_Flux_XSec_2D_nu(samplekey));
-      } else if ( std::regex_search(name, matches_MINERvA_NukeCC1pip_1D, pattern_MINERvA_NukeCC1pip_1D) && matches_MINERvA_NukeCC1pip_1D.size() == 3 ){
+
+      } else if ( !name.compare("MINERvA_NukeCC1pip_CH_XSec_1Dpmu_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1Dthmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1Dplmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1Dptmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1DQ2_nu")   ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1DWexp_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1DTpi_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_CH_XSec_1Dthpi_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1Dpmu_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1Dthmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1Dplmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1Dptmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1DQ2_nu")   ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1DWexp_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1DTpi_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_C_XSec_1Dthpi_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1Dpmu_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1Dthmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1Dplmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1Dptmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1DQ2_nu")   ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1DWexp_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1DTpi_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_H2O_XSec_1Dthpi_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1Dpmu_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1Dthmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1Dplmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1Dptmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1DQ2_nu")   ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1DWexp_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1DTpi_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_Pb_XSec_1Dthpi_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1Dpmu_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1Dthmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1Dplmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1Dptmu_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1DQ2_nu")   ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1DWexp_nu") ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1DTpi_nu")  ||
+                  !name.compare("MINERvA_NukeCC1pip_Fe_XSec_1Dthpi_nu")) {
         return (new MINERvA_NukeCC1pip_XSec_1D_nu(samplekey));
 
         /*

--- a/src/MINERvA/MINERvA_NukeCC1pip_XSec_1D_nu.cxx
+++ b/src/MINERvA/MINERvA_NukeCC1pip_XSec_1D_nu.cxx
@@ -25,68 +25,79 @@ void MINERvA_NukeCC1pip_XSec_1D_nu::SetupDataSettings(){
 
   std::string name = fSettings.GetS("name");
 
-  // Define a regular expression pattern to match the format
-  std::regex pattern("MINERvA_NukeCC1pip_(.*?)_XSec_1D(.*?)_nu");
-
-  std::string target_str;
-  std::string distribution_str;
-  std::smatch matches;
-  if(std::regex_search(name, matches, pattern)) {
-    if(matches.size() == 3) {
-      target_str = matches[1];
-      distribution_str = matches[2];
-    }
+  // Have C, CH, H2O, Fe, Pb target
+  std::string target_str = "";
+  if (name.find("MINERvA_NukeCC1pip_CH_XSec_1D")      != std::string::npos) {
+    fTarget = kCH;
+    target_str = "CH";
   }
-  else{
-    NUIS_ABORT("Name should be MINERvA_NukeCC1pip_<Target>_XSec_1D<Distribution>_nu, but " << name << " is given");
+  else if (name.find("MINERvA_NukeCC1pip_C_XSec_1D")  != std::string::npos) {
+    fTarget = kC;
+    target_str = "C";
+  }
+  else if (name.find("MINERvA_NukeCC1pip_H2O_XSec_1D")!= std::string::npos) {
+    fTarget = kH2O;
+    target_str = "H2O";
+  }
+  else if (name.find("MINERvA_NukeCC1pip_Pb_XSec_1D") != std::string::npos) {
+    fTarget = kPb;
+    target_str = "Pb";
+  }
+  else if (name.find("MINERvA_NukeCC1pip_Fe_XSec_1D") != std::string::npos) {
+    fTarget = kFe;
+    target_str = "Fe";
+  }
+  else {
+    std::cerr << "Could not find appropriate target for " << name << std::endl;
   }
 
-  if(target_str=="CH") fTarget = CH;
-  else if(target_str=="C") fTarget = C;
-  else if(target_str=="H2O") fTarget = H2O;
-  else if(target_str=="Fe") fTarget = Fe;
-  else if(target_str=="Pb") fTarget = Pb;
-  else{
-    NUIS_ABORT("Unknown target: " << target_str);
-  }
-
+  std::string distribution_str = "";
   std::string titles = "";
-  if(distribution_str=="pmu"){
-    fDistribution = kpmu;
+  // Find the distribution
+  if (name.find("_XSec_1Dpmu_nu")       != std::string::npos) {
+    fDistribution = kPmu;
+    distribution_str = "pmu";
     titles    = "p_{#mu} (GeV);d#sigma/dp_{#mu} (cm^{2}/nucleon/GeV)";
-  }
-  else if(distribution_str=="thmu"){
-    fDistribution = kthmu;
+  } 
+  else if (name.find("_XSec_1Dthmu_nu") != std::string::npos) {
+    fDistribution = kThmu;
+    distribution_str = "thmu";
     titles    = "#theta_{#mu} (deg);d#sigma/d#theta_{#mu} (cm^{2}/nucleon/deg)";
   }
-  else if(distribution_str=="plmu"){
-    fDistribution = kplmu;
+  else if (name.find("_XSec_1Dplmu_nu") != std::string::npos) {
+    fDistribution = kPlmu;
+    distribution_str = "plmu";
     titles    = "p_{#mu,||} (GeV);d#sigma/dp_{#mu,||} (cm^{2}/nucleon/GeV)";
   }
-  else if(distribution_str=="ptmu"){
-    fDistribution = kptmu;
+  else if (name.find("_XSec_1Dptmu_nu") != std::string::npos) {
+    fDistribution = kPtmu;
+    distribution_str = "ptmu";
     titles    = "p_{#mu,T} (GeV);d#sigma/dp_{#mu,T} (cm^{2}/nucleon/GeV)";
   }
-  else if(distribution_str=="Q2"){
+  else if (name.find("_XSec_1DQ2_nu")   != std::string::npos) {
     fDistribution = kQ2;
+    distribution_str = "Q2";
     titles    = "Q^{2} (GeV^{2});d#sigma/dQ^{2} (cm^{2}/nucleon/GeV^{2})";
-  }
-  else if(distribution_str=="Wexp"){
+  } 
+  else if (name.find("_XSec_1DWexp_nu") != std::string::npos) {
     fDistribution = kWexp;
+    distribution_str = "Wexp";
     titles    = "W_{exp} (GeV/c^{2});d#sigma/dW_{exp} (cm^{2}/nucleon/(GeV/c^{2}))";
   }
-  else if(distribution_str=="Tpi"){
+  else if (name.find("_XSec_1DTpi_nu")  != std::string::npos) {
     fDistribution = kTpi;
+    distribution_str = "Tpi";
     titles    = "T_{#pi} (GeV);d#sigma/dT_{#pi} (cm^{2}/nucleon/GeV)";
   }
-  else if(distribution_str=="thpi"){
-    fDistribution = kthpi;
+  else if (name.find("_XSec_1Dthpi_nu") != std::string::npos) {
+    fDistribution = kThpi;
+    distribution_str = "thpi";
     titles    = "#theta_{#pi} (deg);d#sigma/d#theta_{#pi} (cm^{2}/nucleon/deg)";
+  } 
+  else {
+    std::cerr << "Could not find appropriate distribution for " << name << std::endl;
   }
-  else{
-    NUIS_ABORT("Unknown distribution: " << distribution_str);
-  }
-
+  std::cout << name << " " << target_str << " " << distribution_str << std::endl;
 
   std::string distdescript = "";
   std::string datafile = "NukeCC1pip_"+target_str+"_"+distribution_str;
@@ -99,10 +110,8 @@ void MINERvA_NukeCC1pip_XSec_1D_nu::SetupDataSettings(){
 
   fSettings.SetDataInput( GeneralUtils::GetTopLevelDir()+"/data/MINERvA/NukeCC1pip/" + datafile + ".txt" );
   fSettings.SetCovarInput( GeneralUtils::GetTopLevelDir()+"/data/MINERvA/NukeCC1pip/" + datafile + "_cov_total.txt" );
-  fSettings.SetXTitle(  GeneralUtils::ParseToStr(titles,";")[0] );
-  fSettings.SetYTitle( GeneralUtils::ParseToStr(titles,";")[1] );
-
-  return;
+  fSettings.SetXTitle(GeneralUtils::ParseToStr(titles,";")[0]);
+  fSettings.SetYTitle(GeneralUtils::ParseToStr(titles,";")[1]);
 }
 
 //********************************************************************
@@ -113,7 +122,7 @@ MINERvA_NukeCC1pip_XSec_1D_nu::MINERvA_NukeCC1pip_XSec_1D_nu(nuiskey samplekey) 
   fSettings = LoadSampleSettings(samplekey);
   fSettings.SetAllowedTypes("FIX,FREE,SHAPE/DIAG,FULL/NORM/MASK", "FIX/FULL");
   fSettings.SetEnuRange(0., 20.0);
-  fSettings.DefineAllowedTargets("C,H"); // TODO Does nothing for now?
+  fSettings.DefineAllowedTargets("C,H,Pb,Fe,H2O"); // TODO Does nothing for now?
   fSettings.DefineAllowedSpecies("numu");
   SetupDataSettings();
 
@@ -128,7 +137,6 @@ MINERvA_NukeCC1pip_XSec_1D_nu::MINERvA_NukeCC1pip_XSec_1D_nu(nuiskey samplekey) 
 
   // Final setup  ---------------------------------------------------
   FinaliseMeasurement();
-
 };
 
 //********************************************************************
@@ -137,8 +145,9 @@ void MINERvA_NukeCC1pip_XSec_1D_nu::FillEventVariables(FitEvent *event) {
 
   fXVar = -999.9;
   if (event->NumFSParticle(PhysConst::pdg_charged_pions) == 0 ||
-      event->NumFSParticle(13) == 0)
+      event->NumFSParticle(13) == 0) {
     return;
+  }
 
   TLorentzVector Pnu = event->GetHMISParticle(14)->fP;
   TLorentzVector Pmu = event->GetHMFSParticle(13)->fP;
@@ -151,15 +160,15 @@ void MINERvA_NukeCC1pip_XSec_1D_nu::FillEventVariables(FitEvent *event) {
   float Q2_true = -1 * (Pmu - Pnu).Mag2()/1E6;
   double Tpi = (Ppip.E() - Ppip.Mag())/1E3; // GeV
 
-  switch(fDistribution){
-    case kpmu:  fXVar = Pmu.Vect().Mag()/1.E3; break;
-    case kthmu: fXVar = (180.0/M_PI)*FitUtils::th(Pnu, Pmu); break;
-    case kplmu: fXVar = pz_mu/1000.; break;
-    case kptmu: fXVar = pt_mu.Mag()/1000.; break;
+  switch (fDistribution){
+    case kPmu:  fXVar = Pmu.Vect().Mag()/1.E3; break;
+    case kThmu: fXVar = (180.0/M_PI)*FitUtils::th(Pnu, Pmu); break;
+    case kPlmu: fXVar = pz_mu/1000.; break;
+    case kPtmu: fXVar = pt_mu.Mag()/1000.; break;
     case kQ2:   fXVar = Q2_true; break;
     case kWexp: fXVar = FitUtils::Wrec(Pnu, Pmu)/1000.; break;
     case kTpi:  fXVar = Tpi; break;
-    case kthpi: fXVar = (180.0/M_PI)*FitUtils::th(Pnu, Ppip); break;
+    case kThpi: fXVar = (180.0/M_PI)*FitUtils::th(Pnu, Ppip); break;
     default: NUIS_ABORT("DIST NOT FOUND : " << fDistribution);
   }
 

--- a/src/MINERvA/MINERvA_NukeCC1pip_XSec_1D_nu.h
+++ b/src/MINERvA/MINERvA_NukeCC1pip_XSec_1D_nu.h
@@ -21,29 +21,28 @@
 #define MINERvA_NukeCC1pip_XSec_1D_NU_H_SEEN
 
 #include "Measurement1D.h"
-#include <regex>
 
 class MINERvA_NukeCC1pip_XSec_1D_nu : public Measurement1D {
 
 public:
 
   enum target {
-    CH,
-    C,
-    H2O,
-    Fe,
-    Pb,
+    kCH,
+    kC,
+    kH2O,
+    kFe,
+    kPb,
   };
 
   enum distribution {
-    kpmu,
-    kthmu,
-    kplmu,
-    kptmu,
+    kPmu,
+    kThmu,
+    kPlmu,
+    kPtmu,
     kQ2,
     kWexp,
     kTpi,
-    kthpi,
+    kThpi,
   };
 
   MINERvA_NukeCC1pip_XSec_1D_nu(nuiskey samplekey);


### PR DESCRIPTION
…ex is C++ standard dependent, and we still have people using old standards. More game-breaking is that it ruins our nuissamples script which checks which samples have been implemented. Otherwise implementation was great (and I can see why original author used regex... there's a lot of samples)